### PR TITLE
Bump dependent-sum version

### DIFF
--- a/dependent-sum-template.cabal
+++ b/dependent-sum-template.cabal
@@ -23,6 +23,6 @@ Library
   exposed-modules:      Data.GADT.Compare.TH
                         Data.GADT.Show.TH
   build-depends:        base >= 3 && <5,
-                        dependent-sum >= 0.2 && < 0.4,
+                        dependent-sum >= 0.2 && < 0.5,
                         template-haskell,
                         th-extras >= 0.0.0.2


### PR DESCRIPTION
@ryantrinkle GHC 8 compatibility was added only in version 0.4 of `dependent-sum` - did you use patched version of `dependent-sum`?