### PR TITLE
 Make the *Tag classes cope with nested GADTs.

### DIFF
--- a/dependent-sum-template.cabal
+++ b/dependent-sum-template.cabal
@@ -24,7 +24,7 @@ Library
                         Data.GADT.Show.TH
   other-modules:        Data.Dependent.Sum.TH.Internal
   build-depends:        base >= 3 && <5,
-                        dependent-sum >= 0.2 && < 0.5,
+                        dependent-sum >= 0.2 && < 0.6,
                         template-haskell,
                         th-extras >= 0.0.0.2
 


### PR DESCRIPTION
Hopefully we can ditch these for `constraint-extras` stuff, but this works as a stop-gap.

847d178 is unrelated and should be upstreamed separately.

CC @cgibbard