### PR TITLE
Add support for GHC 8.8

### DIFF
--- a/src/Data/Dependent/Sum/TH/Internal.hs
+++ b/src/Data/Dependent/Sum/TH/Internal.hs
@@ -59,14 +59,23 @@ deriveForDec className makeClassHead f (DataD dataCxt name bndrs cons _) = retur
         inst = instanceD (cxt (map return dataCxt)) (makeClassHead $ conT name) [dec]
         dec = f bndrs cons
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 612
-#if __GLASGOW_HASKELL__ >= 800
+#if __GLASGOW_HASKELL__ >= 808
+deriveForDec className makeClassHead f (DataInstD dataCxt tvBndrs ty _ cons _) = return <$> inst
+#elif __GLASGOW_HASKELL__ >= 800
 deriveForDec className makeClassHead f (DataInstD dataCxt name tyArgs _ cons _) = return <$> inst
 #else
 deriveForDec className makeClassHead f (DataInstD dataCxt name tyArgs cons _) = return <$> inst
 #endif
     where
-        inst = instanceD (cxt (map return dataCxt)) (makeClassHead $ foldl1 appT (map return $ (ConT name : init tyArgs))) [dec]
+        inst = instanceD (cxt (map return dataCxt)) clhead [dec]
+#if __GLASGOW_HASKELL__ >= 808
+        clhead = makeClassHead $ return $ initTy ty
+        bndrs = [PlainTV v | PlainTV v <- maybe [] id tvBndrs]
+        initTy (AppT ty _) = ty
+#else
+        clhead = makeClassHead $ foldl1 appT (map return $ (ConT name : init tyArgs))
         -- TODO: figure out proper number of family parameters vs instance parameters
         bndrs = [PlainTV v | VarT v <- tail tyArgs ]
+#endif
         dec = f bndrs cons
 #endif


### PR DESCRIPTION
GHC 8.8 changes the encoding of data instances, see
https://gitlab.haskell.org/ghc/ghc/wikis/migration/8.8#template-haskell-21500